### PR TITLE
[PR] support assetsPublicPath

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,10 +12,12 @@ function SimpleHtmlPrecompiler (staticDir, paths, options) {
 SimpleHtmlPrecompiler.prototype.apply = function (compiler) {
   var self = this
   compiler.plugin('after-emit', function (compilation, done) {
+    const publicPath = compilation.outputOptions.publicPath || '/'
+
     Promise.all(
       self.paths.map(function (outputPath) {
         return new Promise(function (resolve, reject) {
-          compileToHTML(self.staticDir, outputPath, self.options, function (prerenderedHTML) {
+          compileToHTML(publicPath, self.staticDir, outputPath, self.options, function (prerenderedHTML) {
             if (self.options.postProcessHtml) {
               prerenderedHTML = self.options.postProcessHtml({
                 html: prerenderedHTML,

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ function SimpleHtmlPrecompiler (staticDir, paths, options) {
 SimpleHtmlPrecompiler.prototype.apply = function (compiler) {
   var self = this
   compiler.plugin('after-emit', function (compilation, done) {
-    const publicPath = compilation.outputOptions.publicPath || '/'
+    const publicPath = compilation.outputOptions.publicPath
 
     Promise.all(
       self.paths.map(function (outputPath) {

--- a/lib/compile-to-html.js
+++ b/lib/compile-to-html.js
@@ -1,9 +1,12 @@
 var Hapi = require('hapi')
 var Inert = require('inert')
 var Path = require('path')
+var Fs = require('fs')
 var Phantom = require('phantomjs-prebuilt')
 var ChildProcess = require('child_process')
 var PortFinder = require('portfinder')
+
+const pathPlaceholder = '/publicPathPlaceholder/'
 
 module.exports = function (publicPath, staticDir, route, options, callback) {
   function serveAndPrerenderRoute () {
@@ -30,9 +33,13 @@ module.exports = function (publicPath, staticDir, route, options, callback) {
           method: 'GET',
           path: route,
           handler: function (request, reply) {
-            reply.file(
-              indexPath
-            )
+            if (publicPath === '/') {
+              reply.file(indexPath)
+              return
+            }
+
+            const indexContent = Fs.readFileSync(indexPath, 'utf-8').replace(new RegExp(publicPath, 'gi'), pathPlaceholder)
+            reply(indexContent)
           }
         })
 
@@ -48,8 +55,7 @@ module.exports = function (publicPath, staticDir, route, options, callback) {
           //   }
           // }
           handler: function (request, reply) {
-            // @TODO: cdn support
-            const filePath = request.url.path.replace(publicPath, '/')
+            const filePath = request.url.path.replace(pathPlaceholder, '/')
             reply.file(
               Path.join(staticDir, filePath)
             )
@@ -90,7 +96,13 @@ module.exports = function (publicPath, staticDir, route, options, callback) {
                     if (stderr) throw stderr
                   }
                 }
-                callback(stdout)
+
+                if (publicPath === '/') {
+                  callback(stdout)
+                } else {
+                  callback(stdout.replace(new RegExp(pathPlaceholder, 'gi'), publicPath))
+                }
+
                 Server.stop()
               }
             )

--- a/lib/compile-to-html.js
+++ b/lib/compile-to-html.js
@@ -5,7 +5,7 @@ var Phantom = require('phantomjs-prebuilt')
 var ChildProcess = require('child_process')
 var PortFinder = require('portfinder')
 
-module.exports = function (staticDir, route, options, callback) {
+module.exports = function (publicPath, staticDir, route, options, callback) {
   function serveAndPrerenderRoute () {
     PortFinder.getPort(function (error, port) {
       if (error) throw error
@@ -39,13 +39,20 @@ module.exports = function (staticDir, route, options, callback) {
         Server.route({
           method: 'GET',
           path: '/{param*}',
-          handler: {
-            directory: {
-              path: '.',
-              redirectToSlash: true,
-              index: true,
-              showHidden: true
-            }
+          // handler: {
+          //   directory: {
+          //     path: '.',
+          //     redirectToSlash: true,
+          //     index: true,
+          //     showHidden: true
+          //   }
+          // }
+          handler: function (request, reply) {
+            // @TODO: cdn support
+            const filePath = request.url.path.replace(publicPath, '/')
+            reply.file(
+              Path.join(staticDir, filePath)
+            )
           }
         })
 


### PR DESCRIPTION
```
// https://github.com/chrisvfritz/prerender-spa-plugin/issues/61
    new PrerenderSpaPlugin(
      // Absolute path to compiled SPA
      path.join(__dirname, '../dist'),
      // List of routes to prerender
      ['/'],
      {
        postProcessHtml: function (context) {
          return context.html.replace(
            /http:\/\/localhost:[0-9]{4}/gi, ''
          ).replace(/id=\"app\"/gi, 'id="app" v-cloak')
        }
      }
    )

[v-cloak] {
display: none;
}

1.assetsPublicPath 为 '/' 时页面中的链接会被替换成 localhost 域名，需要渲染完成后替换回来
2.添加 v-cloak 防止预渲染的页面首屏闪烁

```